### PR TITLE
Add `compatible` flags for skipping `enb` modtype;

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,10 @@ function install(files: string[],
 }
 
 function gameSupported(gameId: string) {
+  const game = util.getGame(gameId);
+  if (game.compatible?.deployToGameDirectory === false || game.compatible?.enb === false) {
+    return false;
+  }
   return !['factorio', 'microsoftflightsimulator'].includes(gameId);
 }
 


### PR DESCRIPTION
As per Nexus-Mods/Vortex#9665 and Nexus-Mods/extension-modtype-dinput#1 , adds a `compatible` flag for skipping the ENB mod type entirely